### PR TITLE
Fixed tests if python is python3

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
 endif(CMAKE_SYSTEM_NAME STREQUAL Windows)
 
+find_package(PythonInterp 2 REQUIRED)
 
 ################################################################################
 # now some functions and settings to make adding tests easy
@@ -89,6 +90,7 @@ function( add_compare_test
     -Dcompare_file=${cmpfile}
     -Dcompare_mode=${cmpmode}
     -Ddist_mode=${distmode}
+    -DPYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
     -P ${CMAKE_SOURCE_DIR}/run_compare.cmake
     ) 
 endfunction()

--- a/tests/run_compare.cmake
+++ b/tests/run_compare.cmake
@@ -44,10 +44,10 @@ separate_arguments( test_args )
 #endif()
 #set(output_test ${CMAKE_CURRENT_BINARY_DIR}/${output_test})
 
-message("python ${CMAKE_CURRENT_LIST_DIR}/run.py ${CMAKE_CURRENT_BINARY_DIR}/${test_cmd} ${dist_mode} ${output_test} ${test_env} ${test_args}")
+message("${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/run.py ${CMAKE_CURRENT_BINARY_DIR}/${test_cmd} ${dist_mode} ${output_test} ${test_env} ${test_args}")
 
 execute_process(
-   COMMAND python ${CMAKE_CURRENT_LIST_DIR}/run.py ${CMAKE_CURRENT_BINARY_DIR}/${test_cmd} ${dist_mode} ${output_test} "${test_env}" ${test_args} RESULT_VARIABLE hadd_error
+   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/run.py ${CMAKE_CURRENT_BINARY_DIR}/${test_cmd} ${dist_mode} ${output_test} "${test_env}" ${test_args} RESULT_VARIABLE hadd_error
 )
 
 if(had_error)
@@ -55,10 +55,10 @@ if(had_error)
   #FATAL_ERROR?
 endif(had_error)
 
-message("python ${CMAKE_CURRENT_LIST_DIR}/compare.py ${output_blessed} ${compare_file} ${compare_mode}")
+message("${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/compare.py ${output_blessed} ${compare_file} ${compare_mode}")
 
 execute_process(
-   COMMAND python ${CMAKE_CURRENT_LIST_DIR}/compare.py ${output_blessed} ${compare_file} ${compare_mode} RESULT_VARIABLE differs
+   COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/compare.py ${output_blessed} ${compare_file} ${compare_mode} RESULT_VARIABLE differs
 )
 
 if(differs)


### PR DESCRIPTION
On some distributions /usr/bin/python is python3, but python scripts
in tests/ are python2. To solve this, detect python and hand if over
to run_compare.cmake.
