### PR TITLE
Fix compile error in raytracer sample

### DIFF
--- a/CMake.inc
+++ b/CMake.inc
@@ -67,7 +67,7 @@ set(CMAKE_PREFIX_PATH "${TBBROOT}/lib/${PARCH}/gcc4.4" "${TBBROOT}/lib/${PARCH}/
 find_library(TBB_LIB tbb)
 find_library(TBBMALLOC_LIB tbbmalloc)
 set(CNC_ADD_LIBS ${CNC_ADD_LIBS} optimized ${TBB_LIB} optimized ${TBBMALLOC_LIB})
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+if (CMAKE_BUILD_TYPE STREQUAL "Debug" OR ";${CMAKE_CONFIGURATION_TYPES};" MATCHES ";Debug;")
   find_library(TBB_LIB_DBG tbb_debug)
   find_library(TBBMALLOC_LIB_DBG tbbmalloc_debug)
   set(CNC_ADD_LIBS ${CNC_ADD_LIBS} debug ${TBB_LIB_DBG} debug ${TBBMALLOC_LIB_DBG})

--- a/samples/raytracer/raytracer/raytracer.cpp
+++ b/samples/raytracer/raytracer/raytracer.cpp
@@ -310,7 +310,7 @@ int main( int argc, char* argv[] )
 {
     std::cout << "Hello!\n";
 
-    ray_tracer cnc_ray_tracer = ray_tracer();
+    ray_tracer cnc_ray_tracer;
  //    CnC::debug::trace(cnc_ray_tracer.frame);
  //   CnC::debug::trace(cnc_ray_tracer.frame_fragment);
  //   CnC::debug::trace(cnc_ray_tracer.execution_time);


### PR DESCRIPTION
I got some compile error while testing samples in ubuntu 14.04: 

- Build Environment: Ubuntu 14.04, gcc 4.8.2
- Error: /icnc/samples/raytracer/raytracer/raytracer.cpp:313:44: error: use of deleted function ‘ray_tracer::ray_tracer(ray_tracer&&)’
- class `ray_tracer` implicitly non-movable and to be simple, there's no reason to move-assign here.

And I had to install these package to compile samples. 

    sudo apt-get install libssl-dev
    sudo apt-get install libmysqlcppconn-dev

It would be better if these packages are indicated in the README file. 