### PR TITLE
private derive fix for CnC::context

### DIFF
--- a/cnc/cnc.h
+++ b/cnc/cnc.h
@@ -550,7 +550,7 @@ namespace CnC {
        This yields more maintanable code and future versions of CnC may require this convention. 
     **/
     template< class Derived >
-    class /*CNC_API*/ context : private Internal::context_base
+    class /*CNC_API*/ context : protected Internal::context_base
     {
     public:
         /// default constructor


### PR DESCRIPTION
CnC::context should public or protected derive CnC::context_base.

C++ no longer allow the derivation of classes that have private virtual base classes: http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_closed.html#7

Current icnc code compiles under gcc-4.9, but fails under clang-3.6, as the latter implemented above DR7.